### PR TITLE
Described current install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,14 @@ end
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
-
   1. Add eredisx to your list of dependencies in `mix.exs`:
 
+        def deps do
+          [{:eredisx, git: "git@github.com:hagiyat/eredisx.git"}]
+        end
+
+  **If [available in Hex](https://hex.pm/docs/publish)**, the package can be installed as:
+  
         def deps do
           [{:eredisx, "~> 0.0.1"}]
         end


### PR DESCRIPTION
I think it's worth to describe how to install eredisx **now** without hex repository.
